### PR TITLE
Fix broken weekly release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release & Publish
 
 on:
-  schedule:
-    - cron: '0 0 * * MON'
   workflow_dispatch:
     inputs:
       version_type:


### PR DESCRIPTION
## Summary
- The `Release & Publish` workflow has failed on **every single run** for at least 7 months (checked ~30 runs back to January 2026, 100% failure rate, all triggered by the weekly `schedule` cron).
- Root cause: `version_type` is a `workflow_dispatch`-only input. On the `schedule` trigger, `${{ github.event.inputs.version_type }}` is empty, so the version-bump step runs bare `npm version` (no argument) instead of `npm version patch/minor/major`. That doesn't bump anything — it dumps the full Node/npm/V8 version info object to stdout, which then gets written to `$GITHUB_OUTPUT` and breaks GitHub Actions' output-file format, failing the job immediately. This matches the consistent ~15–18s failure time on every scheduled run.
- Both `.github/RELEASE.md` and `.github/WORKFLOWS.md` already document this workflow as **manual dispatch only** — there's no documented intent for an automatic weekly release, and no successful schedule-triggered run has ever occurred. So this removes the `schedule` trigger entirely, leaving `workflow_dispatch` as the sole trigger, matching the documented/actual usage pattern.

## Test plan
- [x] YAML validated (`js-yaml` parse)
- [x] `.github/RELEASE.md` / `.github/WORKFLOWS.md` re-checked — no other references to a scheduled/weekly release to update
- [ ] Next manual `workflow_dispatch` run of "Release & Publish" should now correctly bump the version and publish (not verifiable without actually triggering a release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)