### PR TITLE
docs: modernize README (logo, badges, simpler structure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <h1 align="center">CounterAPI JavaScript Client</h1>
 
 <p align="center">
+  A tiny, typed JavaScript/TypeScript client for <a href="https://counterapi.dev">CounterAPI</a> — a hosted counter behind a URL, for page views, feature usage, or anything else you want to count.
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/npm/v/counterapi.svg" alt="npm version"></a>
   <a href="https://github.com/counterapi/counter.js/actions/workflows/main.yml"><img src="https://github.com/counterapi/counter.js/actions/workflows/main.yml/badge.svg" alt="CI"></a>
   <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/npm/dm/counterapi.svg" alt="npm downloads"></a>
@@ -12,282 +16,190 @@
   <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/badge/types-included-blue.svg" alt="TypeScript types included"></a>
 </p>
 
-A lightweight, universal JavaScript client for [CounterAPI](https://counterapi.dev) - a simple API for tracking and managing counters.
+## Quick start
 
-> **v3 breaking change:** The CounterAPI v1 API has been retired, and this library now only talks to v2. The `version` and `namespace` config options are gone — configure a `workspace` instead (see [Creating a Client](#creating-a-client)). The TypeScript response types (`CounterResponse`, `CounterStatsResponse`) were also corrected to match what the API actually returns (`{ code, data: {...} }`) — see [Response Types](#response-types).
+```bash
+npm install counterapi
+```
 
-## Getting Started
+```js
+import { Counter } from 'counterapi';
 
-This library is a client for the CounterAPI service — you need a CounterAPI account and workspace before you can count anything with it:
+const counter = new Counter({ workspace: 'my-workspace' });
 
-1. [Sign up for free](https://app.counterapi.dev/register) (no credit card required)
-2. Create a workspace from your dashboard, and grab an access token if you need authenticated/private counters
-3. Install the library and start counting — see [Installation](#installation) below
+const { data } = await counter.up('page-views');
+console.log(`${data.up_count} views so far`);
+```
 
-Full API reference and guides: [docs.counterapi.dev](https://docs.counterapi.dev)
+New here? [Sign up for free](https://app.counterapi.dev/register) (no credit card required) and create a workspace — that's the `workspace` value above. Full guides and API reference live at [docs.counterapi.dev](https://docs.counterapi.dev).
 
-## Features
+> **Upgrading from v2.x?** v3 drops the retired CounterAPI v1 API. The `version` and `namespace` config options are gone — use `workspace` instead — and the response types now match what the API actually returns (`{ code, data: {...} }`). See [Response Shapes](#response-shapes) below.
 
-- Universal JavaScript library (Node.js, browser, ESM)
-- Supports the CounterAPI v2 endpoints
-- Promise-based API
-- TypeScript support
-- Custom error handling
-- Debugging mode
+## Why this library
+
+- **Works everywhere** — Node.js, browser (via CDN or bundler), ESM and CommonJS
+- **Typed** — full TypeScript definitions, no `@types` package needed
+- **Small** — one dependency (axios), nothing else
+- **Simple errors** — every failure comes back as a plain `{ message, status, code }` object
 
 ## Installation
 
 ```bash
 npm install counterapi
+# or
+yarn add counterapi
+```
+
+Or drop it straight into a page:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/counterapi/dist/counter.browser.min.js"></script>
+<script>
+  const counter = new Counter({ workspace: 'my-workspace' });
+</script>
 ```
 
 ## Usage
 
 ### Import
 
-#### ES Modules (recommended)
-
 ```js
+// ESM (recommended)
 import { Counter } from 'counterapi';
-```
 
-#### CommonJS
-
-```js
+// CommonJS
 const { Counter } = require('counterapi');
 ```
 
-#### Browser via CDN
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/counterapi/dist/counter.browser.min.js"></script>
-<script>
-  // Counter is available as a global variable
-  const counter = new Counter({ workspace: 'my-workspace' });
-</script>
-```
-
-### Creating a Client
+### Create a client
 
 ```js
 const counter = new Counter({
-  workspace: 'my-workspace', // Your workspace name
-  debug: false,              // Optional: Enable debug logging
-  timeout: 5000,             // Optional: Request timeout in ms (default: 10000)
-  accessToken: 'your-token'  // Optional: Authentication token for API requests
+  workspace: 'my-workspace',
+  accessToken: 'your-token', // optional — needed for private/authenticated counters
+  timeout: 5000,              // optional — request timeout in ms (default: 10000)
+  debug: false                 // optional — log requests/responses to the console
 });
 ```
 
-### API Methods
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `workspace` | `string` | Yes | Your workspace name |
+| `accessToken` | `string` | No | Auth token for private/authenticated counters |
+| `timeout` | `number` | No | Request timeout in ms (default `10000`) |
+| `debug` | `boolean` | No | Log requests/responses to the console (default `false`) |
 
-#### Get Counter
+### Methods
+
+| Method | Description |
+| --- | --- |
+| `get(name)` | Get the current value of a counter |
+| `up(name)` | Increment a counter by 1 |
+| `down(name)` | Decrement a counter by 1 |
+| `reset(name)` | Reset a counter to 0 |
+| `stats(name)` | Get usage statistics for a counter |
 
 ```js
-// Get the current value of a counter
 const counter = await counterClient.get('page-views');
-console.log(`Up count: ${counter.data.up_count}, Down count: ${counter.data.down_count}`);
+console.log(`Up: ${counter.data.up_count}, Down: ${counter.data.down_count}`);
+
+await counterClient.up('page-views');
+await counterClient.down('page-views');
+await counterClient.reset('page-views');
+
+const stats = await counterClient.stats('page-views');
+console.log(`Today's up count: ${stats.data.stats.today.up}`);
 ```
 
-#### Increment Counter
+### Error handling
+
+Every call is a Promise — failures reject with a plain object:
 
 ```js
-// Increment a counter by 1
-const counter = await counterClient.up('page-views');
-console.log(`Up count: ${counter.data.up_count}, Down count: ${counter.data.down_count}`);
+try {
+  await counterClient.up('page-views');
+} catch (error) {
+  console.error(error.message, error.status, error.code);
+}
 ```
 
-#### Decrement Counter
+### Response shapes
 
-```js
-// Decrement a counter by 1
-const counter = await counterClient.down('page-views');
-console.log(`Up count: ${counter.data.up_count}, Down count: ${counter.data.down_count}`);
-```
+<details>
+<summary><code>get</code> / <code>up</code> / <code>down</code> / <code>reset</code></summary>
 
-#### Reset Counter
-
-```js
-// Reset a counter to 0
-const counter = await counterClient.reset('page-views');
-console.log(counter.message); // "Counter reset successfully"
-```
-
-#### Get Counter Stats
-
-```js
-// Get statistics for a counter
-const result = await counterClient.stats('page-views');
-console.log(`Up count: ${result.data.up_count}`);
-console.log(`Down count: ${result.data.down_count}`);
-console.log(`Today's up count: ${result.data.stats.today.up}`);
-console.log(`This week's down count: ${result.data.stats.this_week.down}`);
-console.log(`Most active hour: ${getMostActiveHour(result.data.stats.temporal.hours)}`);
-```
-
-### Response Types
-
-#### Standard Counter Response
-
-Basic counter operations return a response with this structure:
-
-```js
+```json
 {
-  code: "200",
-  data: {
-    created_at: "2025-06-17T11:33:23Z",
-    description: "",
-    down_count: 4,
-    id: 1,
-    name: "test",
-    slug: "test",
-    team_id: 4,
-    up_count: 4,
-    updated_at: "2025-06-17T11:33:23Z",
-    user_id: 7,
-    workspace_id: 1,
-    workspace_slug: "test"
+  "code": "200",
+  "data": {
+    "id": 1,
+    "name": "test",
+    "slug": "test",
+    "description": "",
+    "up_count": 4,
+    "down_count": 4,
+    "team_id": 4,
+    "user_id": 7,
+    "workspace_id": 1,
+    "workspace_slug": "test",
+    "created_at": "2025-06-17T11:33:23Z",
+    "updated_at": "2025-06-17T11:33:23Z"
   }
 }
 ```
 
-#### Stats Response
+`reset` omits `up_count`/`down_count` from `data`.
 
-The `stats()` method returns a comprehensive statistics object:
+</details>
 
-```js
+<details>
+<summary><code>stats</code></summary>
+
+```json
 {
-  code: "200",
-  data: {
-    id: 1,
-    counter_id: 1,
-    up_count: 6,
-    down_count: 4,
-    stats: {
-      today: {
-        up: 6,
-        down: 4
-      },
-      this_week: {
-        up: 6,
-        down: 4
-      },
-      temporal: {
-        hours: {
-          // Hourly breakdown (00-23)
-          "07": { up: 6, down: 4 },
-          // ... other hours
-        },
-        weekdays: {
-          // Day of week breakdown
-          "monday": { up: 0, down: 0 },
-          "tuesday": { up: 0, down: 0 },
-          "wednesday": { up: 6, down: 4 },
-          // ... other days
-        },
-        quarters: {
-          // Quarterly breakdown
-          "q1": { up: 0, down: 0 },
-          "q2": { up: 6, down: 4 },
-          "q3": { up: 0, down: 0 },
-          "q4": { up: 0, down: 0 }
-        }
+  "code": "200",
+  "message": "Counter stats retrieved successfully",
+  "data": {
+    "id": 1,
+    "counter_id": 1,
+    "up_count": 6,
+    "down_count": 4,
+    "stats": {
+      "today": { "up": 6, "down": 4 },
+      "this_week": { "up": 6, "down": 4 },
+      "temporal": {
+        "hours": { "07": { "up": 6, "down": 4 } },
+        "weekdays": { "wednesday": { "up": 6, "down": 4 } },
+        "quarters": { "q2": { "up": 6, "down": 4 } }
       }
     },
-    created_at: "2025-06-17T11:33:23Z",
-    updated_at: "2025-06-18T07:44:11Z"
-  },
-  message: "Counter stats retrieved successfully"
+    "created_at": "2025-06-17T11:33:23Z",
+    "updated_at": "2025-06-18T07:44:11Z"
+  }
 }
 ```
 
-## Error Handling
+`temporal.hours` covers every hour (`00`–`23`), `weekdays` covers every day, and `quarters` covers `q1`–`q4` — trimmed above for brevity.
 
-Use standard Promise error handling:
-
-```js
-try {
-  const counter = await counterClient.up('page-views');
-} catch (error) {
-  console.error('Error:', error.message);
-  console.error('Status:', error.status);
-  console.error('Code:', error.code);
-}
-```
+</details>
 
 ## Examples
 
-We provide ready-to-use examples to help you get started with CounterAPI:
+Ready-to-run apps in [`./examples`](./examples):
 
-### Browser Example
-
-The [browser example](./examples/browser) demonstrates how to use CounterAPI in a web application:
-
-- Interactive UI for counter operations
-- Display of up and down counts
-- Visualization of counter statistics
-- Real-time API responses
-
-To run the browser example:
+- **[Browser](./examples/browser)** — interactive UI for get/up/down/reset/stats, backed by a local build or the CDN
+- **[Node.js](./examples/node)** — minimal server-side counter fetch with ESM
 
 ```bash
-# Build the library first
-npm run build
-
-# Serve the example using a web server
-cd examples/browser
-python -m http.server 8000
-# Then open http://localhost:8000 in your browser
+npm run build        # build the library first
+cd examples/node && node index.js
 ```
 
-### Node.js Example
+## Documentation & Support
 
-The [Node.js example](./examples/node) shows how to use CounterAPI in a server-side application:
-
-- Simple counter retrieval
-- Using ESM imports
-- Error handling
-
-To run the Node.js example:
-
-```bash
-# Build the library first
-npm run build
-
-# Run the example
-cd examples/node
-node index.js
-```
-
-### Visualizing Stats
-
-You can use the stats data to create visualizations:
-
-```js
-// Example: Creating a simple chart from hourly stats
-function createHourlyChart(stats) {
-  const hours = stats.data.stats.temporal.hours;
-  const labels = Object.keys(hours).sort();
-  const upData = labels.map(hour => hours[hour].up);
-  const downData = labels.map(hour => hours[hour].down);
-  
-  // Use your preferred charting library
-  renderChart({
-    labels,
-    datasets: [
-      { label: 'Up', data: upData },
-      { label: 'Down', data: downData }
-    ]
-  });
-}
-
-// Example usage
-const stats = await counter.stats('my-counter');
-createHourlyChart(stats);
-```
-
-## Documentation
-
-Full API reference, authentication details, and framework-specific guides live at [docs.counterapi.dev](https://docs.counterapi.dev). Don't have an account yet? [Sign up for free](https://app.counterapi.dev/register).
+- Docs: [docs.counterapi.dev](https://docs.counterapi.dev)
+- Sign up: [app.counterapi.dev/register](https://app.counterapi.dev/register)
+- Issues & feature requests: [GitHub Issues](https://github.com/counterapi/counter.js/issues)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# CounterAPI JavaScript Client
+<p align="center">
+  <img src="https://counterapi.dev/img/logo.png" alt="CounterAPI" width="200">
+</p>
+
+<h1 align="center">CounterAPI JavaScript Client</h1>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/npm/v/counterapi.svg" alt="npm version"></a>
+  <a href="https://github.com/counterapi/counter.js/actions/workflows/main.yml"><img src="https://github.com/counterapi/counter.js/actions/workflows/main.yml/badge.svg" alt="CI"></a>
+  <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/npm/dm/counterapi.svg" alt="npm downloads"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/npm/l/counterapi.svg" alt="license"></a>
+  <a href="https://www.npmjs.com/package/counterapi"><img src="https://img.shields.io/badge/types-included-blue.svg" alt="TypeScript types included"></a>
+</p>
 
 A lightweight, universal JavaScript client for [CounterAPI](https://counterapi.dev) - a simple API for tracking and managing counters.
 


### PR DESCRIPTION
## Summary

Two commits:

1. **Logo and badges** — CounterAPI logo centered at the top, plus the standard badge row for a published npm library: npm version, CI status, npm downloads, license, TypeScript types included. All badge/image URLs verified to return 200.

2. **Structural modernization** — reworked the README to be simpler and friendlier to a first-time reader:
   - Leads with a copy-pasteable Quick start (install + minimal snippet) instead of Getting Started -> Features -> Installation -> Usage before any code appears
   - Added a short Why this library section
   - Condensed the five separate get/up/down/reset/stats subsections (each with its own near-duplicate snippet) into one config-options table, one methods table, and a single combined code sample
   - Collapsed the large JSON response-shape examples into <details> so they don't dominate the page, and fixed them to be valid JSON (quoted keys, no inline comments -- they were previously fenced as js despite being plain data, which isn't valid JS at the top level)
   - Merged the two separate "Documentation" sections into one "Documentation & Support" footer
   - Dropped the bundled chart-building example, which added length without covering anything the docs site/examples don't already

No behavioral/code changes -- README only.

Generated with Claude Code