### PR TITLE
chore(ci): bump setup-node and codecov-action, fix deprecated input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v7
       
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -39,9 +39,9 @@ jobs:
       
     - name: Upload coverage to Codecov
       if: matrix.node-version == '20.x'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
-        file: ./coverage/lcov.info
+        files: ./coverage/lcov.info
         flags: unittests
         name: codecov-umbrella
         
@@ -65,7 +65,7 @@ jobs:
       uses: actions/checkout@v7
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -88,7 +88,7 @@ jobs:
       uses: actions/checkout@v7
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '20.x'
         cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22.x'
         cache: 'npm'


### PR DESCRIPTION
## Summary
- `actions/setup-node` v4 → v7 (`main.yml` + `release.yml`)
- `codecov/codecov-action` v5 → v7, and renamed its `file:` input to `files:` — v5 was already logging a deprecation warning for this on every run (\`Unexpected input(s) 'file', valid inputs are [...'files'...]\`, visible in past CI logs), so this just applies the rename that warning was asking for.

Supersedes and closes #568, #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)