### PR TITLE
ci: bump to Node 24, drop Node 20 (EOL)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     
     steps:
     - name: Checkout code
@@ -38,7 +38,7 @@ jobs:
       run: npm run test:coverage
       
     - name: Upload coverage to Codecov
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '22.x'
       uses: codecov/codecov-action@v7
       with:
         files: ./coverage/lcov.info
@@ -67,12 +67,12 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '22.x'
+        node-version: '24.x'
         cache: 'npm'
-        
+
     - name: Install dependencies
       run: npm ci
-      
+
     - name: Run security audit
       # Scoped to production dependencies: dist/ is prebuilt before publish, so
       # devDependency vulnerabilities (build/release tooling) never reach consumers.
@@ -90,7 +90,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: 'npm'
         
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '22.x'
+        node-version: '24.x'
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary

Node 20 reached end-of-life in April 2026 — same situation as the Node 18 drop a few PRs back, no point testing a runtime that's no longer maintained.

- CI test matrix: `[20.x, 22.x]` → `[22.x, 24.x]`
- The three jobs pinned to a single Node version (Security Audit, Integration Tests, Release & Publish) move to `24.x`
- Codecov upload condition updated to match the new matrix (`22.x` instead of the now-removed `20.x`)

Supersedes and closes the stale Renovate PR #524.

## Explicitly not changed

- **`engines.node`** stays at `>=18`
- **`@types/node`** stays at `^22.0.0`

Unlike the earlier Node 18 case (where `@rollup/plugin-terser`'s upgraded dependency literally threw `ReferenceError: crypto is not defined` on Node 18, a real technical incompatibility), there's no actual runtime constraint here — the shipped library only needs `axios` and ES2020, nothing Node 22/24-specific. `engines` is a compatibility promise to consumers, not a mirror of what CI happens to test, so narrowing it isn't warranted by this change alone.

## Test plan
- [x] `npm run typecheck` / `npm run lint` / `npm test` / `npm run build` all pass locally
- [x] Workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)